### PR TITLE
Feature/example grid

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -91,21 +91,39 @@ header {
 }
 
 .example {
+  display: grid;
+  grid-template-columns: [explain] 50% [code] 50% [end];
+
   tr:hover {
     background: #f0f0f0;
     .code-td { background: #e0e0e0; }
   }
+
+  table {
+    grid-column: explain / end;
+    .explanation, .code-td { width: 50%; }
+  }
+
   .explanation {
-    width: 50%;
     box-sizing: border-box;
     padding-right: 10px;
     vertical-align: baseline;
   }
 
-  .code-td {
-    width: 50%;
+  .code-td, .code-cell {
     background: #eee;
     border-left: solid 2px #aaa;
     vertical-align: baseline;
+    overflow-y: auto;
+  }
+
+  > .explanation { grid-column: explain; }
+  > .code-cell { grid-column: code; }
+
+  @media(max-width: 600px) {
+    & { grid-template-columns: [everything] 100%; }
+    > .explanation { grid-column: everything; }
+    > .code-cell { grid-column: everything; }
+
   }
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -94,11 +94,6 @@ header {
   display: grid;
   grid-template-columns: [explain] 50% [code] 50% [end];
 
-  tr:hover {
-    background: #f0f0f0;
-    .code-td { background: #e0e0e0; }
-  }
-
   table {
     grid-column: explain / end;
     .explanation, .code-td { width: 50%; }


### PR DESCRIPTION
This allows us to style this a little more flexibly on mobile:

![Mobile view of the website](https://user-images.githubusercontent.com/4346137/71262131-e37c4600-2336-11ea-993e-3e0ab1b09a1c.png)

I need to perform corresponding changes in `amc-example` (and install it on CI). Right now the CSS will handle both the current table template and the future grid-style one.